### PR TITLE
chore: create issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Request new sites to be added
+    url: https://github.com/StopMalwareContent/Site-Tracker/issues/new?assignees=Nitrrine&labels=website+add&projects=&template=report-a-threat.md&title=Add+%28url+goes+here%29+to+the+blocklist
+    about: If you think we should add a new website to the list, go here.
+  - name: Report a false-positive
+    url: https://github.com/StopMalwareContent/Site-Tracker/issues/new?assignees=Nitrrine&labels=website+remove&projects=&template=report-a-false-positive.md&title=Remove+%28url+goes+here%29+from+block+list
+    about: If a website is mislabeled in your opinion, report that here.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The main reason is that StopModReposts is **not being actively mantained**, but 
 
 ### Can I report a new website?
 
-Sure! It's very simple, just [Click here](https://github.com/StopMalwareContent/Extension/issues/new?assignees=&labels=website+add&projects=&template=report-a-threat.md&title=Add+%3Creplace+with+url%3E) to open an issue about a new threat.
+Sure! It's very simple, just [Click here](https://github.com/StopMalwareContent/Site-Tracker/issues/new?assignees=Nitrrine&labels=website+add&projects=&template=report-a-threat.md&title=Add+%28url+goes+here%29+to+the+blocklist) to open an issue about a new threat.
 
 ### There is a false-positive!
 
-If StopMalwareContent is flagging something that it shouldn't, just [Click here](https://github.com/StopMalwareContent/Extension/issues/new?assignees=&labels=website+remove&projects=&template=report-a-false-positive.md&title=Remove+%3Creplace+with+url%3E) to open an issue about a false-positive.
+If StopMalwareContent is flagging something that it shouldn't, just [Click here](https://github.com/StopMalwareContent/Site-Tracker/issues/new?assignees=Nitrrine&labels=website+remove&projects=&template=report-a-false-positive.md&title=Remove+%28url+goes+here%29+from+block+list) to open an issue about a false-positive.
 
 ## Contributors
 


### PR DESCRIPTION
Since site add/removal requests are now located at StopMalwareContent/Sites-Tracker, this adds 2 extra buttons to the new issues page, directing people there.